### PR TITLE
Fixed version.h include path in Base.hsc

### DIFF
--- a/src/Menoh/Base.hsc
+++ b/src/Menoh/Base.hsc
@@ -7,7 +7,7 @@ import Foreign
 import Foreign.C
 
 #include <menoh/menoh.h>
-#include <menoh/version.hpp>
+#include <menoh/version.h>
 
 type MenohDType = #type menoh_dtype
 


### PR DESCRIPTION
I tried build and noticed my `stack build` will fail like below.

```shell
$ stack build
menoh-0.1.0: build (lib + exe)
Preprocessing library for menoh-0.1.0..
/Users/lotz/Documents/workspace/menoh-haskell/Base.hsc:10:10: fatal error: 'menoh/version.hpp' file not found
#include <menoh/version.hpp>
         ^~~~~~~~~~~~~~~~~~~
1 error generated.
compiling .stack-work/dist/x86_64-osx/Cabal-2.0.1.0/build/Menoh/Base_hsc_make.c failed (exit code 1)
command was: /usr/bin/gcc -c .stack-work/dist/x86_64-osx/Cabal-2.0.1.0/build/Menoh/Base_hsc_make.c -o .stack-work/dist/x86_64-osx/Cabal-2.0.1.0/build/Menoh/Base_hsc_make.o -m64 -fno-stack-protector -m64 -fno-stack-protector ...
```

And I also found there is `menoh/version.h` (instead of `version.hpp`) in include dir.

It seems to be changed the name but I couldn't find the history on git.
<https://github.com/pfnet-research/menoh/blob/master/menoh/CMakeLists.txt#L12-L13>

I hope this PR will help this project :)
