### PR TITLE
 change ToBuffer/FromBuffer instances to be element-type specific

### DIFF
--- a/menoh.cabal
+++ b/menoh.cabal
@@ -80,3 +80,16 @@ executable mnist_example
   default-language: Haskell2010
   If !flag(buildexamples)
     buildable: False
+
+Test-suite Test
+  type:              exitcode-stdio-1.0
+  hs-source-dirs:    test
+  main-is:           test.hs
+  build-depends:
+      base >=4 && <5
+    , menoh
+    , vector
+    , tasty >=0.10.1
+    , tasty-hunit >=0.9 && <0.11
+    , tasty-th
+  default-language: Haskell2010

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,0 +1,58 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+import qualified Data.Vector as V
+import qualified Data.Vector.Generic as VG
+import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Unboxed as VU
+import Foreign
+
+import Test.Tasty.HUnit
+import Test.Tasty.TH
+
+import Menoh
+
+------------------------------------------------------------------------
+
+case_basicWriteBuffer_vector ::  Assertion
+case_basicWriteBuffer_vector = do
+  allocaArray 9 $ \(p :: Ptr Float) -> do
+    basicWriteBuffer DTypeFloat [3,3] (castPtr p) (VG.tail (V.fromList xs))
+    ys <- peekArray 9 p
+    ys @?= (tail xs)
+  where
+    xs = [0..9]
+
+case_basicWriteBuffer_vector_storable ::  Assertion
+case_basicWriteBuffer_vector_storable = do
+  allocaArray 9 $ \(p :: Ptr Float) -> do
+    basicWriteBuffer DTypeFloat [3,3] (castPtr p) (VG.tail (VS.fromList xs))
+    ys <- peekArray 9 p
+    ys @?= tail xs
+  where
+    xs = [0..9]
+
+case_basicWriteBuffer_vector_unboxed ::  Assertion
+case_basicWriteBuffer_vector_unboxed = do
+  allocaArray 9 $ \(p :: Ptr Float) -> do
+    basicWriteBuffer DTypeFloat [3,3] (castPtr p) (VG.tail (VU.fromList xs))
+    ys <- peekArray 9 p
+    ys @?= tail xs
+  where
+    xs = [0..9]
+
+case_basicWriteBuffer_list ::  Assertion
+case_basicWriteBuffer_list = do
+  allocaArray 9 $ \(p :: Ptr Float) -> do
+    basicWriteBuffer DTypeFloat [3,3] (castPtr p) (map V.fromList xss)
+    ys <- peekArray 9 p
+    ys @?= concat xss
+  where
+    xss = [[1,2,3], [4,5,6], [7,8,9]]
+
+------------------------------------------------------------------------
+-- Test harness
+
+main :: IO ()
+main = $(defaultMainGenerator)


### PR DESCRIPTION
instances of the form `(Storable a, HasDType a) => ToVector (Vector a)` is problematic, because there is a case where `Storable` instance is incompatible with representation in buffer. For example boolean value will be represented as 1 byte in Menoh but `Bool` instance of `Storable` assumes `sizeof(int)` representation in C.
